### PR TITLE
chore: update .gitignore to exclude build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,12 @@ yarn-debug.log*
 yarn-error.log*
 
 # Build outputs
+dist/
 build/
 out/
+*.js
+*.d.ts
+*.js.map
 
 # Keep TypeScript source files
 !src/**/*.ts
@@ -36,7 +40,6 @@ coverage/
 .cache/
 .npm/
 .eslintcache
-.ropeproject
 
 # Version files (generated)
 .version


### PR DESCRIPTION
Add dist/, JavaScript files (*.js, *.js.map), and TypeScript 
declaration files (*.d.ts) to .gitignore to prevent build outputs 
from being committed. Remove obsolete .ropeproject entry.  
These changes keep the repository clean from generated files and 
improve source management.