### PR TITLE
Grant workflow permission and adjust package version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-semantic-versioning",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "AI-powered semantic versioning for GitHub Actions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Fix GitHub Actions release permission error and set correct package version.

Add explicit write permission for contents in the workflow to allow the
integration to create releases and update repository contents. This fixes
"Resource not accessible by integration" errors when pushing from the
main branch.

Also update package.json version from 1.0.0 to 0.0.1, reflecting the
intended project versioning state.