### PR TITLE
Commit dist directory for CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Build outputs
-dist/
+# dist/ is committed for GitHub Actions
 build/
 out/
 *.js


### PR DESCRIPTION
Ensure the dist directory is not ignored so GitHub Actions can add and push build artifacts. The .gitignore comment clarifies that dist/ is intentionally committed for CI (previously it was ignored which caused the action to fail when attempting to git add dist/). This prevents the CI workflow from exiting with an error about ignored paths when creating commits for built files.