### PR TITLE
ci(release): add write permissions for contents in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
       - 'tsconfig.json'
       - 'action.yml'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Grant write access to the contents permission in the release workflow
to enable actions that require modifying repository contents during
the release process. This change ensures the workflow can update files
or create tags as needed for releases.