### PR TITLE
ci-trigger-release-on-test-success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Build and Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Test AI Semantic Versioning"]
+    types:
+      - completed
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'tsconfig.json'
-      - 'action.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "semver": "^7.6.0",
         "simple-git": "^3.28.0",
         "toml": "^3.0.0",
-        "yaml": "^2.3.4"
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^7.6.0",
     "simple-git": "^3.28.0",
     "toml": "^3.0.0",
-    "yaml": "^2.3.4"
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
- Changed the release workflow trigger from direct pushes to the completion of the Test AI Semantic Versioning workflow to ensure releases only occur after successful tests.
- Updated the build job to run conditionally based on the success of the upstream workflow_run.
- Removed push-specific path filters that became unnecessary after switching to the workflow_run trigger.
- Upgraded the yaml dependency from version 2.3.4 to 2.8.1 to improve compatibility, include bug fixes, and maintain security.